### PR TITLE
fix: add id field to the coupons

### DIFF
--- a/coupon/model.go
+++ b/coupon/model.go
@@ -107,6 +107,7 @@ type CouponProduct struct {
 }
 
 type Coupon struct {
+	ID      int
 	Type    CouponType
 	Details CouponDetails
 }


### PR DESCRIPTION
- earlier we relied on the index for id
- however this could result in a awkward work around after deletion
- say we had 5 coupons (0 - 4) and we delete the index 3, now we have 0,1,2,4. The GET /coupons API will return them in that order, however as a consumer of the API now the index of the 4th item is 3 but it is 4 internally which is correct behavior but bad user experience